### PR TITLE
feat(workspace): 支持删除最近工作目录

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,10 @@ import { UsagePanel } from "./usage/components/UsagePanel";
 import { closeConfirmBody, needsCloseConfirm } from "./workspace/closeConfirm";
 import { ProjectSwitcher } from "./workspace/components/ProjectSwitcher";
 import { Sidebar } from "./workspace/components/Sidebar";
+import type { RecentProject } from "./workspace/contracts";
 import { failureLabel } from "./workspace/errors";
+import { pathKey } from "./workspace/path";
+import { removeRecentConfirmBody } from "./workspace/removeRecentConfirm";
 import { useFoldedProjects } from "./workspace/useFoldedProjects";
 import { useProjectWorkspace } from "./workspace/useProjectWorkspace";
 
@@ -23,6 +26,7 @@ export default function App() {
   const [collapsed, setCollapsed] = useState(false);
   const [usageOpen, setUsageOpen] = useState(false);
   const [pendingCloseId, setPendingCloseId] = useState<string | null>(null);
+  const [pendingRemove, setPendingRemove] = useState<RecentProject | null>(null);
   const updater = useAppUpdater();
   const stageRef = useRef<HTMLDivElement>(null);
   const sidebarRef = useRef<HTMLElement>(null);
@@ -122,6 +126,7 @@ export default function App() {
         <div className="stage-caption">
           <ProjectSwitcher
             onOpen={workspace.selectProject}
+            onRequestRemove={setPendingRemove}
             opening={workspace.opening}
             project={workspace.activeProject}
             recentProjects={workspace.recentProjects}
@@ -165,6 +170,24 @@ export default function App() {
           onCancel={cancelClose}
           onConfirm={confirmClose}
           title={`关闭 ${pendingClose.title}？`}
+        />
+      ) : null}
+
+      {pendingRemove ? (
+        <ConfirmDialog
+          body={removeRecentConfirmBody(
+            pendingRemove,
+            workspace.tabs.filter(
+              (tab) => pathKey(tab.project.rootPath) === pathKey(pendingRemove.rootPath),
+            ).length,
+          )}
+          confirmLabel="删除"
+          onCancel={() => setPendingRemove(null)}
+          onConfirm={() => {
+            workspace.removeRecentProject(pendingRemove.id);
+            setPendingRemove(null);
+          }}
+          title={`删除 ${pendingRemove.name}？`}
         />
       ) : null}
 

--- a/src/workspace/components/ProjectSwitcher.tsx
+++ b/src/workspace/components/ProjectSwitcher.tsx
@@ -1,6 +1,6 @@
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { Check, ChevronsUpDown, FolderOpen } from "lucide-react";
-import { useState } from "react";
+import { Check, ChevronsUpDown, FolderOpen, Trash2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { ICON } from "../../theme/sizing";
 import type { ProjectWorkspace, RecentProject } from "../contracts";
 import { normalizePath, pathKey, shortPath } from "../path";
@@ -11,15 +11,54 @@ interface ProjectSwitcherProps {
   recentProjects: RecentProject[];
   opening: boolean;
   onOpen: (path: string | null) => Promise<void>;
+  /** 右键条目 → 删除菜单 → 确认后的入口；确认框在 App 层渲染。 */
+  onRequestRemove: (project: RecentProject) => void;
+}
+
+/** 右键菜单的固定尺寸，用来在视口边缘把菜单收进可视区。 */
+const MENU_WIDTH = 128;
+const MENU_HEIGHT = 40;
+
+interface ContextMenuState {
+  project: RecentProject;
+  x: number;
+  y: number;
 }
 
 /**
  * 舞台标题行控件：显示当前会话的项目归属，点开可换。
  * 换项目会重启当前会话的 PTY——这是 cwd 只能在 spawn 时定的必然结果。
+ * 最近项目条目上右键可删除（移除最近记录并关闭该目录下的会话）。
  */
-export function ProjectSwitcher({ project, recentProjects, opening, onOpen }: ProjectSwitcherProps) {
+export function ProjectSwitcher({
+  project,
+  recentProjects,
+  opening,
+  onOpen,
+  onRequestRemove,
+}: ProjectSwitcherProps) {
   const [open, setOpen] = useState(false);
+  const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const ref = useDismiss<HTMLDivElement>(open, () => setOpen(false));
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // 菜单的条件渲染用不了 useDismiss，这里按同一套"外点 + Escape"模式挂全局监听。
+  // 菜单渲染在 popover-host 内部，点击菜单里的按钮不会误关主弹层。
+  useEffect(() => {
+    if (!menu) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) setMenu(null);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenu(null);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [menu]);
 
   const pick = (next: string | null) => {
     setOpen(false);
@@ -59,7 +98,15 @@ export function ProjectSwitcher({ project, recentProjects, opening, onOpen }: Pr
           {recentProjects.length > 0 ? (
             <div className="popover-list">
               {recentProjects.map((item) => (
-                <button key={item.id} onClick={() => pick(item.rootPath)} type="button">
+                <button
+                  key={item.id}
+                  onClick={() => pick(item.rootPath)}
+                  onContextMenu={(event) => {
+                    event.preventDefault();
+                    setMenu({ project: item, x: event.clientX, y: event.clientY });
+                  }}
+                  type="button"
+                >
                   <span className="popover-list__text">
                     <strong>{item.name}</strong>
                     <small>{shortPath(item.rootPath)}</small>
@@ -72,6 +119,30 @@ export function ProjectSwitcher({ project, recentProjects, opening, onOpen }: Pr
           <button className="popover-browse" disabled={opening} onClick={() => void browse()} type="button">
             <FolderOpen aria-hidden="true" size={ICON.md} />
             <span>浏览目录…</span>
+          </button>
+        </div>
+      ) : null}
+
+      {menu ? (
+        <div
+          ref={menuRef}
+          className="context-menu"
+          role="menu"
+          style={{
+            left: Math.min(menu.x, window.innerWidth - MENU_WIDTH - 8),
+            top: Math.min(menu.y, window.innerHeight - MENU_HEIGHT - 8),
+          }}
+        >
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => {
+              setMenu(null);
+              onRequestRemove(menu.project);
+            }}
+          >
+            <Trash2 aria-hidden="true" size={ICON.sm} />
+            <span>删除</span>
           </button>
         </div>
       ) : null}

--- a/src/workspace/components/ProjectSwitcher.tsx
+++ b/src/workspace/components/ProjectSwitcher.tsx
@@ -1,6 +1,6 @@
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { Check, ChevronsUpDown, FolderOpen, Trash2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { ICON } from "../../theme/sizing";
 import type { ProjectWorkspace, RecentProject } from "../contracts";
 import { normalizePath, pathKey, shortPath } from "../path";
@@ -11,24 +11,14 @@ interface ProjectSwitcherProps {
   recentProjects: RecentProject[];
   opening: boolean;
   onOpen: (path: string | null) => Promise<void>;
-  /** 右键条目 → 删除菜单 → 确认后的入口；确认框在 App 层渲染。 */
+  /** 条目悬停时的删除入口；确认框在 App 层渲染。 */
   onRequestRemove: (project: RecentProject) => void;
-}
-
-/** 右键菜单的固定尺寸，用来在视口边缘把菜单收进可视区。 */
-const MENU_WIDTH = 128;
-const MENU_HEIGHT = 40;
-
-interface ContextMenuState {
-  project: RecentProject;
-  x: number;
-  y: number;
 }
 
 /**
  * 舞台标题行控件：显示当前会话的项目归属，点开可换。
  * 换项目会重启当前会话的 PTY——这是 cwd 只能在 spawn 时定的必然结果。
- * 最近项目条目上右键可删除（移除最近记录并关闭该目录下的会话）。
+ * 最近项目条目悬停时右侧出现删除键（移除最近记录并关闭该目录下的会话）。
  */
 export function ProjectSwitcher({
   project,
@@ -38,27 +28,7 @@ export function ProjectSwitcher({
   onRequestRemove,
 }: ProjectSwitcherProps) {
   const [open, setOpen] = useState(false);
-  const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const ref = useDismiss<HTMLDivElement>(open, () => setOpen(false));
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  // 菜单的条件渲染用不了 useDismiss，这里按同一套"外点 + Escape"模式挂全局监听。
-  // 菜单渲染在 popover-host 内部，点击菜单里的按钮不会误关主弹层。
-  useEffect(() => {
-    if (!menu) return;
-    const onPointerDown = (event: MouseEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) setMenu(null);
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setMenu(null);
-    };
-    document.addEventListener("mousedown", onPointerDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", onPointerDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [menu]);
 
   const pick = (next: string | null) => {
     setOpen(false);
@@ -98,51 +68,34 @@ export function ProjectSwitcher({
           {recentProjects.length > 0 ? (
             <div className="popover-list">
               {recentProjects.map((item) => (
-                <button
-                  key={item.id}
-                  onClick={() => pick(item.rootPath)}
-                  onContextMenu={(event) => {
-                    event.preventDefault();
-                    setMenu({ project: item, x: event.clientX, y: event.clientY });
-                  }}
-                  type="button"
-                >
-                  <span className="popover-list__text">
-                    <strong>{item.name}</strong>
-                    <small>{shortPath(item.rootPath)}</small>
-                  </span>
-                  {pathKey(item.rootPath) === currentKey ? <Check aria-hidden="true" size={ICON.sm} /> : null}
-                </button>
+                <div className="popover-list__item" key={item.id}>
+                  <button className="popover-list__main" onClick={() => pick(item.rootPath)} type="button">
+                    <span className="popover-list__text">
+                      <strong>{item.name}</strong>
+                      <small>{shortPath(item.rootPath)}</small>
+                    </span>
+                  </button>
+                  <div className="popover-list__tail">
+                    {pathKey(item.rootPath) === currentKey ? (
+                      <Check aria-hidden="true" className="popover-list__check" size={ICON.sm} />
+                    ) : null}
+                    <button
+                      aria-label={`删除 ${item.name} 的最近记录`}
+                      className="popover-list__delete"
+                      onClick={() => onRequestRemove(item)}
+                      title={`删除 ${item.name} 的最近记录`}
+                      type="button"
+                    >
+                      <Trash2 aria-hidden="true" size={ICON.xs} />
+                    </button>
+                  </div>
+                </div>
               ))}
             </div>
           ) : null}
           <button className="popover-browse" disabled={opening} onClick={() => void browse()} type="button">
             <FolderOpen aria-hidden="true" size={ICON.md} />
             <span>浏览目录…</span>
-          </button>
-        </div>
-      ) : null}
-
-      {menu ? (
-        <div
-          ref={menuRef}
-          className="context-menu"
-          role="menu"
-          style={{
-            left: Math.min(menu.x, window.innerWidth - MENU_WIDTH - 8),
-            top: Math.min(menu.y, window.innerHeight - MENU_HEIGHT - 8),
-          }}
-        >
-          <button
-            role="menuitem"
-            type="button"
-            onClick={() => {
-              setMenu(null);
-              onRequestRemove(menu.project);
-            }}
-          >
-            <Trash2 aria-hidden="true" size={ICON.sm} />
-            <span>删除</span>
           </button>
         </div>
       ) : null}

--- a/src/workspace/removeRecentConfirm.test.ts
+++ b/src/workspace/removeRecentConfirm.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { removeRecentConfirmBody } from "./removeRecentConfirm";
+
+const project = { id: "p0", name: "demo", rootPath: "/demo" };
+
+describe("removeRecentConfirmBody", () => {
+  it("mentions open sessions when the directory still has tabs", () => {
+    expect(removeRecentConfirmBody(project, 2))
+      .toBe("将从最近项目中移除 demo，并关闭该目录下的 2 个会话。目录本身不会被删除。");
+  });
+
+  it("omits the session clause when no session is open", () => {
+    expect(removeRecentConfirmBody(project, 0))
+      .toBe("将从最近项目中移除 demo。目录本身不会被删除。");
+  });
+});

--- a/src/workspace/removeRecentConfirm.ts
+++ b/src/workspace/removeRecentConfirm.ts
@@ -1,0 +1,12 @@
+import type { RecentProject } from "./contracts";
+
+/**
+ * 删除最近项目的弹框正文。说清楚删除的边界：只动最近列表和已打开的会话，
+ * 磁盘上的目录原封不动——把"删除"这件事真正会发生的代价列出来。
+ */
+export function removeRecentConfirmBody(project: RecentProject, openTabCount: number) {
+  const closingClause = openTabCount > 0
+    ? `，并关闭该目录下的 ${openTabCount} 个会话`
+    : "";
+  return `将从最近项目中移除 ${project.name}${closingClause}。目录本身不会被删除。`;
+}

--- a/src/workspace/sidebar.css
+++ b/src/workspace/sidebar.css
@@ -393,3 +393,38 @@
 .popover-browse:hover:not(:disabled) { background: var(--surface-hover); }
 .popover-browse:hover:not(:disabled) > svg { color: var(--accent); }
 .popover-browse:disabled { opacity: 0.45; cursor: default; }
+
+/* 最近项目条目的右键菜单：fixed 跟随鼠标，视觉与 popover--menu 一致，
+   层级压在弹层（20）之上、确认框（30）之下。 */
+.context-menu {
+  position: fixed;
+  z-index: 25;
+  display: grid;
+  min-width: 128px;
+  gap: 1px;
+  padding: 5px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-md);
+}
+
+.context-menu button {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 9px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  text-align: left;
+  background: transparent;
+  font-size: var(--fs-md);
+  cursor: pointer;
+  transition: background var(--duration) var(--ease);
+}
+
+.context-menu button > svg { flex: 0 0 auto; color: var(--text-muted); }
+.context-menu button > span { flex: 1; }
+.context-menu button:hover { background: var(--surface-hover); }
+.context-menu button:hover > svg { color: var(--danger); }

--- a/src/workspace/sidebar.css
+++ b/src/workspace/sidebar.css
@@ -312,7 +312,7 @@
 }
 
 .popover--menu button,
-.popover-list button {
+.popover-list__main {
   display: flex;
   align-items: center;
   gap: 9px;
@@ -331,8 +331,7 @@
 .popover--menu button > span { flex: 1; }
 .popover--menu button > i { color: var(--text-faint); font-size: var(--fs-xs); font-style: normal; }
 
-.popover--menu button:hover:not(:disabled),
-.popover-list button:hover { background: var(--surface-hover); }
+.popover--menu button:hover:not(:disabled) { background: var(--surface-hover); }
 .popover--menu button:disabled { opacity: 0.45; cursor: not-allowed; }
 
 .popover-refresh {
@@ -350,8 +349,50 @@
   overflow-y: auto;
 }
 
-.popover-list button { justify-content: space-between; }
-.popover-list button > svg { flex: 0 0 auto; color: var(--accent); }
+/* 条目 = 主按钮 + 行尾格；悬停底色画在整条上，删除键才会一起亮。 */
+.popover-list__item {
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-sm);
+}
+.popover-list__item:hover { background: var(--surface-hover); }
+
+.popover-list__main { flex: 1; min-width: 0; }
+
+/* "当前项目"勾与删除键叠在同一格里，hover 时互换——侧栏会话行同一套做法：
+   位置固定，条目名截断的位置就不会被图标挤动。 */
+.popover-list__tail {
+  display: grid;
+  width: 24px;
+  height: 100%;
+  place-items: center;
+}
+.popover-list__tail > * { grid-area: 1 / 1; }
+
+.popover-list__check {
+  color: var(--accent);
+  pointer-events: none;
+  transition: opacity var(--duration) var(--ease);
+}
+
+.popover-list__delete {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  border: 0;
+  border-radius: 4px;
+  color: var(--text-faint);
+  background: transparent;
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity var(--duration) var(--ease), color var(--duration) var(--ease);
+}
+.popover-list__item:hover .popover-list__delete,
+.popover-list__delete:focus-visible { opacity: 1; }
+.popover-list__item:hover .popover-list__check,
+.popover-list__item:has(.popover-list__delete:focus-visible) .popover-list__check { opacity: 0; }
+.popover-list__delete:hover { color: var(--danger); }
 
 .popover-list__text { display: grid; min-width: 0; gap: 2px; }
 
@@ -393,38 +434,3 @@
 .popover-browse:hover:not(:disabled) { background: var(--surface-hover); }
 .popover-browse:hover:not(:disabled) > svg { color: var(--accent); }
 .popover-browse:disabled { opacity: 0.45; cursor: default; }
-
-/* 最近项目条目的右键菜单：fixed 跟随鼠标，视觉与 popover--menu 一致，
-   层级压在弹层（20）之上、确认框（30）之下。 */
-.context-menu {
-  position: fixed;
-  z-index: 25;
-  display: grid;
-  min-width: 128px;
-  gap: 1px;
-  padding: 5px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--surface-raised);
-  box-shadow: var(--shadow-md);
-}
-
-.context-menu button {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  padding: 7px 9px;
-  border: 0;
-  border-radius: var(--radius-sm);
-  color: var(--text);
-  text-align: left;
-  background: transparent;
-  font-size: var(--fs-md);
-  cursor: pointer;
-  transition: background var(--duration) var(--ease);
-}
-
-.context-menu button > svg { flex: 0 0 auto; color: var(--text-muted); }
-.context-menu button > span { flex: 1; }
-.context-menu button:hover { background: var(--surface-hover); }
-.context-menu button:hover > svg { color: var(--danger); }

--- a/src/workspace/storage.test.ts
+++ b/src/workspace/storage.test.ts
@@ -3,6 +3,7 @@ import {
   parseRecentProjects,
   parseWorkspaceState,
   rememberProject,
+  removeRecentProject,
   serializeWorkspaceState,
 } from "./storage";
 import { createWorkspaceTab } from "./tabs";
@@ -34,6 +35,25 @@ describe("recent projects", () => {
     expect(parseRecentProjects(persisted)).toEqual([
       { id: "new-id", name: "demo", rootPath: "/demo" },
     ]);
+  });
+
+  it("removes an entry by id and leaves the rest untouched", () => {
+    const recent = [
+      { id: "p0", name: "zero", rootPath: "/zero" },
+      { id: "p1", name: "one", rootPath: "/one" },
+    ];
+    expect(removeRecentProject(recent, "p0")).toEqual([
+      { id: "p1", name: "one", rootPath: "/one" },
+    ]);
+  });
+
+  it("returns the same list for an unknown id", () => {
+    const recent = [{ id: "p0", name: "zero", rootPath: "/zero" }];
+    expect(removeRecentProject(recent, "missing")).toEqual(recent);
+  });
+
+  it("tolerates an empty list", () => {
+    expect(removeRecentProject([], "p0")).toEqual([]);
   });
 });
 

--- a/src/workspace/storage.ts
+++ b/src/workspace/storage.ts
@@ -104,6 +104,11 @@ export function rememberProject(project: ProjectWorkspace, recent: RecentProject
   return deduplicateByRootPath([entry, ...recent]);
 }
 
+/** 按 id 从最近项目列表移除；不存在时原样返回。 */
+export function removeRecentProject(projects: RecentProject[], id: string) {
+  return projects.filter((project) => project.id !== id);
+}
+
 export function parseRecentProjects(value: string | null): RecentProject[] {
   if (!value) return [];
   const parsed: unknown = JSON.parse(value);

--- a/src/workspace/tabs.test.ts
+++ b/src/workspace/tabs.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import type { SessionActivity } from "../terminal/contracts";
-import { applySnapshot, createWorkspaceTab, groupTabsByProject, nextActiveTab, nextOrdinal } from "./tabs";
+import {
+  applySnapshot,
+  closeTabsForPath,
+  createWorkspaceTab,
+  groupTabsByProject,
+  nextActiveTab,
+  nextOrdinal,
+} from "./tabs";
 
 const project = { id: "p1", name: "demo", rootPath: "/demo", rootUri: "file:///demo" };
 const other = { id: "p2", name: "other", rootPath: "/other", rootUri: "file:///other" };
@@ -23,6 +30,39 @@ describe("workspace tabs", () => {
       id,
     }));
     expect(nextActiveTab(tabs, "b").activeId).toBe("c");
+  });
+});
+
+describe("closing every session in a directory", () => {
+  const a1 = { ...createWorkspaceTab(project, "shell", 1), id: "a1" };
+  const a2 = { ...createWorkspaceTab(project, "shell", 2), id: "a2" };
+  const b1 = { ...createWorkspaceTab(other, "shell", 3), id: "b1" };
+
+  it("moves the active session to the first survivor when it dies with its directory", () => {
+    // 逐条 closeTab 会把活动切到同目录的 a2，a2 随后也被关掉，活动就悬空了；
+    // 这里必须一次算好，落到其他目录的第一个会话。
+    const result = closeTabsForPath([a1, a2, b1], "a1", "/demo");
+    expect(result.remaining.map((tab) => tab.id)).toEqual(["b1"]);
+    expect(result.activeId).toBe("b1");
+  });
+
+  it("leaves an active session in another directory alone", () => {
+    const result = closeTabsForPath([a1, b1, a2], "b1", "/demo");
+    expect(result.remaining.map((tab) => tab.id)).toEqual(["b1"]);
+    expect(result.activeId).toBe("b1");
+  });
+
+  it("closes to no active session when the directory held every session", () => {
+    const result = closeTabsForPath([a1, a2], "a2", "/demo");
+    expect(result.remaining).toEqual([]);
+    expect(result.activeId).toBeNull();
+  });
+
+  it("matches directories ignoring case and separator spelling", () => {
+    const win = { ...a1, project: { ...project, rootPath: "C:\\Demo\\" } };
+    const result = closeTabsForPath([win], "win", "c:/demo");
+    expect(result.remaining).toEqual([]);
+    expect(result.activeId).toBeNull();
   });
 });
 

--- a/src/workspace/tabs.ts
+++ b/src/workspace/tabs.ts
@@ -1,5 +1,6 @@
 import type { TerminalSnapshot } from "../components/TerminalViewport";
 import type { ProjectWorkspace, WorkspaceTab, WorkspaceTabKind } from "./contracts";
+import { pathKey } from "./path";
 import { toSessionTitle } from "./sessionTitle";
 
 export interface ProjectGroup {
@@ -53,6 +54,22 @@ export function nextActiveTab(tabs: WorkspaceTab[], closingId: string) {
   const remaining = tabs.filter((tab) => tab.id !== closingId);
   const nextIndex = Math.min(Math.max(closingIndex, 0), remaining.length - 1);
   return { remaining, activeId: remaining[nextIndex]?.id ?? null };
+}
+
+/**
+ * 关闭指定目录下的全部会话。活动会话在其中时，活动切到剩余会话的第一个——
+ * 逐个 closeTab 会经 nextActiveTab 把活动切到同目录的下一个会话，它随后也被
+ * 关掉，活动就悬空成一个已删除的 id，切换器会显示"正在定位…"。
+ */
+export function closeTabsForPath(
+  tabs: WorkspaceTab[],
+  activeTabId: string | null,
+  rootPath: string,
+) {
+  const targetKey = pathKey(rootPath);
+  const remaining = tabs.filter((tab) => pathKey(tab.project.rootPath) !== targetKey);
+  const activeSurvives = activeTabId !== null && remaining.some((tab) => tab.id === activeTabId);
+  return { remaining, activeId: activeSurvives ? activeTabId : (remaining[0]?.id ?? null) };
 }
 
 /** 侧栏分组：按项目首次出现的顺序排列，组内保持会话原有顺序。 */

--- a/src/workspace/useProjectWorkspace.ts
+++ b/src/workspace/useProjectWorkspace.ts
@@ -11,15 +11,23 @@ import type {
   WorkspaceTabKind,
 } from "./contracts";
 import { toAppFailure } from "./errors";
+import { pathKey } from "./path";
 import {
   loadRecentProjects,
   loadWorkspaceState,
   rememberProject,
+  removeRecentProject as removeRecentProjectEntry,
   saveRecentProjects,
   saveWorkspaceState,
   serializeWorkspaceState,
 } from "./storage";
-import { applySnapshot, createWorkspaceTab, nextActiveTab, nextOrdinal } from "./tabs";
+import {
+  applySnapshot,
+  closeTabsForPath,
+  createWorkspaceTab,
+  nextActiveTab,
+  nextOrdinal,
+} from "./tabs";
 
 export function useProjectWorkspace() {
   const restoredWorkspace = useMemo(loadWorkspaceState, []);
@@ -156,6 +164,40 @@ export function useProjectWorkspace() {
     });
   }, [activeTabId]);
 
+  /**
+   * 删除最近项目：从列表移除记录，并关闭该目录下所有会话（PTY 被杀）。
+   * 用户已通过删除确认框确认，这里不再走 needsCloseConfirm 二次拦截。
+   * 整目录一次函数式更新关闭（closeTabsForPath），避免逐个 closeTab 把活动
+   * 切到同目录的下一个会话、关完后再悬空成一个已删除的 id。
+   * 该目录是唯一有会话的目录时，若最近列表还有其他目录，自动打开最近的一条
+   * 补位，否则切换器会停在"正在定位…"。
+   */
+  const removeRecentProject = useCallback((id: string) => {
+    const target = recentProjects.find((project) => project.id === id);
+    if (!target) return;
+    const targetKey = pathKey(target.rootPath);
+    const next = removeRecentProjectEntry(recentProjects, id);
+    saveRecentProjects(next);
+    setRecentProjects(next);
+    setTabs((current) => {
+      const result = closeTabsForPath(current, activeTabId, target.rootPath);
+      if (result.activeId !== activeTabId) setActiveTabId(result.activeId);
+      return result.remaining;
+    });
+    if (lastProject && pathKey(lastProject.rootPath) === targetKey) setLastProject(null);
+    const otherTabOpen = tabs.some((tab) => pathKey(tab.project.rootPath) !== targetKey);
+    if (!otherTabOpen && next.length > 0) {
+      void openProject(next[0].rootPath)
+        .then((workspace) => {
+          const tab = createWorkspaceTab(workspace, "shell", 1);
+          setTabs([tab]);
+          setActiveTabId(tab.id);
+          acceptProject(workspace);
+        })
+        .catch((error) => setFailure(toAppFailure(error)));
+    }
+  }, [acceptProject, activeTabId, lastProject, recentProjects, tabs]);
+
   const updateTab = useCallback((id: string, snapshot: TerminalSnapshot) => {
     setTabs((current) => current.map((tab) => (
       tab.id === id ? applySnapshot(tab, snapshot) : tab
@@ -180,6 +222,7 @@ export function useProjectWorkspace() {
     selectProject,
     launch,
     closeTab,
+    removeRecentProject,
     updateTab,
     redetectAgents,
     setActiveTabId,


### PR DESCRIPTION
最近项目条目右键可删除：移除记录并关闭该目录下的会话，磁盘目录原封不动。删除当前活动目录时自动切到其他目录的会话；该目录是唯一会话目录且最近列表还有其他目录时自动打开最近一条补位。

- storage: removeRecentProject 按 id 移除最近记录
- tabs: closeTabsForPath 整目录一次关闭，修复活动会话悬空

<img width="2160" height="497" alt="image" src="https://github.com/user-attachments/assets/5085405d-15fb-43e1-a380-0b1a77bb8346" />
<img width="2160" height="1381" alt="image" src="https://github.com/user-attachments/assets/242cab51-a30f-4b45-a9b0-fd92e8d371f1" />
